### PR TITLE
fix: null-guard getFocusedBlock() in start() to prevent slash-command crash (#5)

### DIFF
--- a/src/operator_toolbar.tsx
+++ b/src/operator_toolbar.tsx
@@ -891,6 +891,14 @@ export function initToolbar(switches: { smartblocks: boolean }) {
     }
 
     const focusedBlock = window.roamAlphaAPI.ui.getFocusedBlock();
+    // getFocusedBlock() returns null when no block is focused — happens
+    // transiently after the 10ms delay above when a slash command (/code,
+    // /h1, etc.) tears down the current textarea and focus is briefly in
+    // the slash menu. Without this guard, focusedBlock["block-uid"] throws
+    // and stop() at the top of start() has already removed the prior
+    // handlers, so the toolbar silently dies for the rest of the session.
+    // See https://github.com/dive2Pro/roam-toolbar/issues/5
+    if (!focusedBlock) return;
     let block = getBlock(focusedBlock["block-uid"]);
 
     const isHeading = (heading: number) => {


### PR DESCRIPTION
Closes #5.

## Summary
One-line null guard on `getFocusedBlock()` at `src/operator_toolbar.tsx:893`. When a user types `/code` (or any slash command that swaps the textarea), the floating toolbar throws `Cannot read properties of null (reading 'block-uid')` and silently dies for the rest of the session.

## Root cause
`start(input)` is wired via `document.arrive("textarea.rm-block-input", ...)` and awaits 10ms before calling `getFocusedBlock()`. Slash commands tear down the current textarea, briefly move focus into the slash menu, then create a fresh textarea — `arrive` fires on the new one, `start()` runs, the 10ms wait elapses, focus is still in the slash menu, `getFocusedBlock()` returns `null`, `null["block-uid"]` throws.

After the throw, `stop()` (called at the top of `start()`) has already removed the previous handlers, so the toolbar disappears until the page reloads.

## The fix
```ts
const focusedBlock = window.roamAlphaAPI.ui.getFocusedBlock();
if (!focusedBlock) return;          // ← added
let block = getBlock(focusedBlock["block-uid"]);
```

`document.arrive` re-fires `start()` whenever a block textarea reappears, so bailing out cleanly here loses nothing — when the user clicks back into a real block, the toolbar reattaches normally.

## Test plan
- [x] Built locally; no TypeScript errors.
- [ ] (Author's verification) Type `/code` in any block → no console error → toolbar still works on text selection afterward.
- [ ] (Author's verification) Other slash commands (`/h1`, `/quote`) also exit cleanly without breaking the toolbar.

## Notes
- Comment in code references issue #5 so future readers can find the context.
- Line 621 (`focusedBlock["block-uid"]` inside `setHeader`) is safe by transitivity — `focusedBlock` is captured in closure at line 893, so the early-return prevents `setHeader` from ever being defined with a null `focusedBlock`.

Happy to revise — first time contributing to this repo. Thanks for maintaining it!